### PR TITLE
decode_responses is now being set to False by default - closes #14

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [bugfix] set decode_responses to False, same as StrictRedis default
+- [enhancement] ability to change decode_responses value
+
 1.2.1
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 -------
 
+- [feature] ability to configure decode_responses for redis client in command line, pytest.ini or factory argument.
 - [bugfix] set decode_responses to False, same as StrictRedis default
 - [enhancement] ability to change decode_responses value
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ You can pick which you prefer, but remember that these settings are handled in t
     * ``Configuration option in your pytest.ini file``
 
 +---------------------------+--------------------------+---------------------+-------------------+-----------------------+
-| Redis option              | Fixture factory argument | Command line option | pytest.ini option | Default               |
+| Redis server option       | Fixture factory argument | Command line option | pytest.ini option | Default               |
 +===========================+==========================+=====================+===================+=======================+
 | executable                | executable               | --redis-exec        | redis_exec        | /usr/bin/redis-server |
 +---------------------------+--------------------------+---------------------+-------------------+-----------------------+
@@ -122,6 +122,14 @@ Example usage:
 
         [pytest]
         redis_port = 8888
+
+Options below are for configuring redis client fixture.
+
++---------------------+--------------------------+---------------------+-------------------+---------+
+| Redis client option | Fixture factory argument | Command line option | pytest.ini option | Default |
++=====================+==========================+=====================+===================+=========+
+| decode_response     | decode                   | --redis-decode      | redis_decode      | False   |
++---------------------+--------------------------+---------------------+-------------------+---------+
 
 Package resources
 -----------------

--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -182,13 +182,14 @@ def redis_proc(
     return redis_proc_fixture
 
 
-def redisdb(process_fixture_name, db=0, strict=True):
+def redisdb(process_fixture_name, db=0, strict=True, decode_responses=False):
     """
     Connection fixture factory for pytest-redis.
 
     :param str process_fixture_name: name of the process fixture
     :param int db: number of database
     :param bool strict: if true, uses StrictRedis client class
+    :param bool decode_responses: See StrictRedis decode_responses parameter
     :rtype: func
     :returns: function which makes a connection to redis
     """
@@ -214,7 +215,11 @@ def redisdb(process_fixture_name, db=0, strict=True):
         redis_class = redis.StrictRedis if strict else redis.Redis
 
         redis_client = redis_class(
-            redis_host, redis_port, redis_db, decode_responses=True)
+            redis_host,
+            redis_port,
+            redis_db,
+            decode_responses=decode_responses
+        )
         request.addfinalizer(redis_client.flushall)
 
         return redis_client

--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -36,7 +36,7 @@ def get_config(request):
     config = {}
     options = [
         'logsdir', 'host', 'port', 'exec', 'timeout', 'loglevel', 'db_count',
-        'save', 'compression', 'rdbchecksum', 'syslog'
+        'save', 'compression', 'rdbchecksum', 'syslog', 'decode'
     ]
     for option in options:
         option_name = 'redis_' + option
@@ -182,14 +182,15 @@ def redis_proc(
     return redis_proc_fixture
 
 
-def redisdb(process_fixture_name, db=0, strict=True, decode_responses=False):
+def redisdb(process_fixture_name, db=0, strict=True, decode=None):
     """
     Connection fixture factory for pytest-redis.
 
     :param str process_fixture_name: name of the process fixture
-    :param int db: number of database
+    :param int db: number of database to use
     :param bool strict: if true, uses StrictRedis client class
-    :param bool decode_responses: See StrictRedis decode_responses parameter
+    :param bool decode_responses: Client: to decode response or not.
+        See redis.StrictRedis decode_reponse client parameter.
     :rtype: func
     :returns: function which makes a connection to redis
     """
@@ -208,11 +209,13 @@ def redisdb(process_fixture_name, db=0, strict=True, decode_responses=False):
         :returns: Redis client
         """
         proc_fixture = request.getfixturevalue(process_fixture_name)
+        config = get_config(request)
 
         redis_host = proc_fixture.host
         redis_port = proc_fixture.port
         redis_db = db
         redis_class = redis.StrictRedis if strict else redis.Redis
+        decode_responses = decode if decode is not None else config['decode']
 
         redis_client = redis_class(
             redis_host,

--- a/src/pytest_redis/plugin.py
+++ b/src/pytest_redis/plugin.py
@@ -32,6 +32,10 @@ _help_compress = "Turn on redis dump files compression."
 _help_rdbchecksum = "Whether to add checksum to the rdb files"
 _help_syslog = "Whether to enable logging to the system logger"
 _help_save = "Redis persistance frequency configuration - seconds keys"
+_help_decode = (
+    "Client: to decode response or not. "
+    "See redis.StrictRedis decode_reponse client parameter."
+)
 
 
 def pytest_addoption(parser):
@@ -90,6 +94,12 @@ def pytest_addoption(parser):
         name='redis_syslog',
         type='bool',
         help=_help_syslog
+    )
+    parser.addini(
+        name='redis_decode',
+        type='bool',
+        help=_help_decode,
+        default=False
     )
 
     parser.addoption(
@@ -158,6 +168,12 @@ def pytest_addoption(parser):
         action="store_true",
         dest='redis_syslog',
         help=_help_syslog
+    )
+    parser.addoption(
+        '--redis-client-decode',
+        action="store_true",
+        dest='redis_decode',
+        help=_help_decode
     )
 
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -16,10 +16,10 @@ def test_redis(redisdb):
     redisdb.set('test2', 'test')
 
     test1 = redisdb.get('test1')
-    assert test1 == 'test'
+    assert test1 == b'test'
 
     test2 = redisdb.get('test2')
-    assert test2 == 'test'
+    assert test2 == b'test'
 
 
 redis_proc2 = factories.redis_proc(port=6381)
@@ -34,13 +34,13 @@ def test_second_redis(redisdb, redisdb2):
     redisdb2.set('test2', 'test_other')
 
     test1 = redisdb.get('test1')
-    assert test1 == 'test'
+    assert test1 == b'test'
 
     test2 = redisdb.get('test2')
-    assert test2 == 'test'
+    assert test2 == b'test'
 
-    assert redisdb2.get('test1') == 'test_other'
-    assert redisdb2.get('test2') == 'test_other'
+    assert redisdb2.get('test1') == b'test_other'
+    assert redisdb2.get('test2') == b'test_other'
 
 
 redis_proc_to_mock = factories.redis_proc(port=None)


### PR DESCRIPTION
    It's the same as the StrictRedis default value.

Added ability to set decode_responses for redis client in redisdb parameter

TODO: 

* [ ] - make this configurable in config