### PR TITLE
Client fixture to connect through socket to redis server - closes #5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGELOG
 unreleased
 -------
 
+- [enhancement] RedisExecutor now provides attribute with path to unixsocket
+- [enhancement] redis client fixture now connects to redis through unixsocket by default
 - [enhancement] Version check got moved to executor, to be run just before starting Redis Server
 - [feature] ability to configure decode_responses for redis client in command line, pytest.ini or factory argument.
 - [bugfix] set decode_responses to False, same as StrictRedis default

--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -109,7 +109,8 @@ class RedisExecutor(TCPExecutor):
         """
         port = kwargs.get('port')
         pidfile = 'redis-server.{port}.pid'.format(port=port)
-        unixsocket = 'redis.{port}.sock'.format(port=port)
+        tmpdir = gettempdir()
+        self.unixsocket = tmpdir + '/redis.{port}.sock'.format(port=port)
         dbfilename = 'dump.{port}.rdb'.format(port=port)
         self.executable = executable
 
@@ -129,13 +130,13 @@ class RedisExecutor(TCPExecutor):
             '--databases', str(databases),
             '--timeout', str(redis_timeout),
             '--pidfile', pidfile,
-            '--unixsocket', unixsocket,
+            '--unixsocket', self.unixsocket,
             '--dbfilename', dbfilename,
             '--logfile', logfile_path,
             '--loglevel', loglevel,
             '--syslog-enabled', self._redis_bool(syslog_enabled),
             '--port', str(port),
-            '--dir', gettempdir()
+            '--dir', tmpdir
         ]
         if save:
             save_parts = save.split()

--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -148,6 +148,7 @@ def redisdb(process_fixture_name, db=0, strict=True, decode=None):
             redis_host,
             redis_port,
             redis_db,
+            unix_socket_path=proc_fixture.unixsocket,
             decode_responses=decode_responses
         )
         request.addfinalizer(redis_client.flushall)


### PR DESCRIPTION
    Process executor will now have attribute with full path to redis server socket