### PR TITLE
Close file descriptor when reading Redis version

### DIFF
--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -171,9 +171,8 @@ class RedisExecutor(TCPExecutor):
 
     def _check_version(self):
         """Check redises version if it's compatible."""
-        version_string = os.popen(
-            '{0} --version'.format(self.executable)
-        ).read()
+        with os.popen('{0} --version'.format(self.executable)) as p:
+            version_string = p.read()
         if not version_string:
             raise RedisMisconfigured(
                 'Bad path to redis_exec is given:'


### PR DESCRIPTION
After recent changes to [pytest](https://docs.pytest.org/en/features/warnings.html)

> Starting from version 3.1, pytest now automatically catches all warnings during test execution and displays them at the end of the session: 

Warnings originating from pytest-redis is printed when running `py.test`
```
  /Users/brunsgaard/.pyenv/versions/3.6.1/lib/python3.6/subprocess.py:761: ResourceWarning: subprocess 55432 is still running
    ResourceWarning, source=self)
  /Users/brunsgaard/.virtualenvs/ocmg-push/lib/python3.6/site-packages/pytest_redis/executor.py:175: ResourceWarning: unclosed file <_io.TextIOWrapper name=15 encoding='UTF-8'>
    '{0} --version'.format(self.executable)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

The warning is totally correct telling the user that a subprocess pipe has not been properly closed.

This PR resolves this issue