### PR TITLE
Fix cut'n'paste error.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ You can also create additional redis client and process fixtures if you'd need t
 
 .. note::
 
-    Each RabbitMQ process fixture can be configured in a different way than the others through the fixture factory arguments.
+    Each Redis process fixture can be configured in a different way than the others through the fixture factory arguments.
 
 Configuration
 =============


### PR DESCRIPTION
Trivial fix to the README, where it appears a cut'n'paste error has left "RabbitMQ" where I think "Redis" is meant.