### PR TITLE
fixes #248 - Parametrize a scope of redisdb fixture in the factory

### DIFF
--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -141,7 +141,9 @@ def redis_noproc(host=None, port=None):
     return redis_nooproc_fixture
 
 
-def redisdb(process_fixture_name, dbnum=0, strict=True, decode=None):
+def redisdb(
+        process_fixture_name, dbnum=0, strict=True, decode=None, scope=None
+):
     """
     Create connection fixture factory for pytest-redis.
 
@@ -150,10 +152,14 @@ def redisdb(process_fixture_name, dbnum=0, strict=True, decode=None):
     :param bool strict: if true, uses StrictRedis client class
     :param bool decode_responses: Client: to decode response or not.
         See redis.StrictRedis decode_reponse client parameter.
+    :param str scope: scope of the pytest fixture
     :rtype: func
     :returns: function which makes a connection to redis
     """
-    @pytest.fixture
+    if scope is None:
+        scope = 'function'
+
+    @pytest.fixture(scope=scope)
     def redisdb_factory(request):
         """
         Create connection for pytest-redis.

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,5 +1,5 @@
 """Module containing all tests for pytest-redis."""
-
+from pytest_redis import factories
 
 def test_redis(redisdb):
     """Check that it's actually working on redis database."""
@@ -37,3 +37,19 @@ def test_external_redis(redisdb2, redisdb2_noop):
 
     assert redisdb2_noop.get('test1') == b'test_other'
     assert redisdb2_noop.get('test2') == b'test_other'
+
+
+def test_fixture_default_scope():
+    """Check that a default fixture scope is 'function'."""
+    redis_my_proc = factories.redis_proc(port=None, logsdir='/tmp')
+    redis_my = factories.redisdb('redis_my_proc')
+
+    assert redis_my._pytestfixturefunction.scope == 'function'
+
+
+def test_fixture_custom_scope():
+    """Check that a default fixture scope is 'function'."""
+    redis_my_proc = factories.redis_proc(port=None, logsdir='/tmp')
+    redis_my = factories.redisdb('redis_my_proc', scope='session')
+
+    assert redis_my._pytestfixturefunction.scope == 'session'


### PR DESCRIPTION
Fixes #248 .
This makes the `redisdb` factory to accept additional, optional parameter: `scope`.
This is used to return a `redisdb` fixture with the desired scope.

The default value remains `function`, so the change is backwards-compatible