### PR TITLE
provide bind option to redis command line

### DIFF
--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -169,6 +169,8 @@ class RedisExecutor(TCPExecutor):
             loglevel,
             "--syslog-enabled",
             self._redis_bool(syslog_enabled),
+            "--bind",
+            str(host),
             "--port",
             str(port),
             "--dir",


### PR DESCRIPTION
although `redis_proc` takes a `host` parameter, it's unused (and at least on my machine) the new redis process listens on all interfaces. this adds the `--bind` parameter to the redis command line so that it listens only on the provided host.

fixes #335 