### PR TITLE
add datadir config parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://raw.githubusercontent.com/ClearcodeHQ/pytest-redis/master/logo.png
     :width: 100px
     :height: 100px
-    
+
 pytest-redis
 ============
 
@@ -195,6 +195,12 @@ You can pick which you prefer, but remember that these settings are handled in t
      - redis_save
      - -
      - ""
+   * - Redis test instance data directory path
+     - datadir
+     - --redis-datadir
+     - redis_datadir
+     - -
+     - ""
 
 Example usage:
 
@@ -232,4 +238,3 @@ Package resources
 -----------------
 
 * Bug tracker: https://github.com/ClearcodeHQ/pytest-redis/issues
-

--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -137,7 +137,7 @@ class RedisExecutor(TCPExecutor):
         """
         if not datadir:
             datadir = Path(gettempdir())
-        self.unixsocket = str(datadir + f"/redis.{port}.sock")
+        self.unixsocket = str(datadir / f"redis.{port}.sock")
         self.executable = executable
 
         logfile_path = datadir / f"redis-server.{port}.log"

--- a/src/pytest_redis/plugin.py
+++ b/src/pytest_redis/plugin.py
@@ -35,6 +35,7 @@ _help_save = "Redis persistance frequency configuration - seconds keys"
 _help_decode = (
     "Client: to decode response or not. " "See redis.StrictRedis decode_reponse client parameter."
 )
+_help_datadir = "Directory where test Redis instance data files will be stored"
 
 
 def pytest_addoption(parser):
@@ -70,6 +71,7 @@ def pytest_addoption(parser):
     parser.addini(name="redis_rdbchecksum", type="bool", help=_help_rdbchecksum)
     parser.addini(name="redis_syslog", type="bool", help=_help_syslog)
     parser.addini(name="redis_decode", type="bool", help=_help_decode, default=False)
+    parser.addini(name="redis_datadir", help=_help_datadir, default=None)
 
     parser.addoption(
         "--redis-exec",
@@ -98,6 +100,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--redis-client-decode", action="store_true", dest="redis_decode", help=_help_decode
     )
+    parser.addoption("--redis-datadir", action="store", dest="redis_datadir", help=_help_datadir)
 
 
 redis_proc = factories.redis_proc()


### PR DESCRIPTION
hi! we've been running into the `UnixSocketTooLong` issue, and was hoping to add a `tmpdir` parameter to redis_proc to set it.

there doesn't seem to be a great way to do this otherwise, either some `tmp_dir_factory` or `tmppath_factory` hacking, always providing `--basetemp` when invoking pytest, or modifying PYTEST_DEBUG_TEMPROOT. all these options also cause all our pytest output to be changed to this new directory, which isn't ideal when all we want is for a working pytest-redis unix domain socket path.

hope you'll consider it, thank you!