### PR TITLE
Make the NoopRedis fixture wait for the server to come up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,23 @@ In order to connect to them, one would be using the ``redis_nooproc`` fixture.
 
         assert redis_external.get("did_it") == 1
 
+Standard configuration options apply to it.
 
-By default the  ``redis_nooproc`` fixture would connect to Redis instance using **6379** port. Standard configuration options apply to it.
+By default the ``redis_nooproc`` fixture would connect to Redis
+instance using **6379** port attempting to make a successful socket
+connection within **15 seconds**. The fixture will block your test run
+within this timeout window. You can overwrite the timeout like so:
+
+
+.. code-block:: python
+
+    # set the blocking wait to 5 seconds
+    redis_external = factories.redis_noproc(timeout=5)
+
+    def test_redis(redis_external):
+        """Check that it's actually working on redis database."""
+        redis_external.set('test1', 'test')
+        # etc etc
 
 These are the configuration options that are working on all levels with the ``redis_nooproc`` fixture:
 

--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -59,7 +59,8 @@ class UnixSocketTooLong(Exception):
 
 class NoopRedis(TCPExecutor):
     """Reddis class respsenting an instance started by a third party."""
-    def __init__(self, host, port, unixsocket, timeout=15):
+
+    def __init__(self, host, port, unixsocket, startup_timeout=15):
         """
         Init method of NoopRedis.
 
@@ -70,8 +71,8 @@ class NoopRedis(TCPExecutor):
         self.host = host
         self.port = port
         self.unixsocket = unixsocket
-        self.timeout = timeout
-        super().__init__([], host, port, timeout=timeout)
+        self.timeout = startup_timeout
+        super().__init__([], host, port, timeout=startup_timeout)
 
     def start(self):
         """Start is a NOOP."""
@@ -111,7 +112,7 @@ class RedisExecutor(TCPExecutor):
         loglevel,
         host,
         port,
-        timeout=60,
+        startup_timeout=60,
         save="",
         daemonize="no",
         rdbcompression=True,
@@ -129,7 +130,7 @@ class RedisExecutor(TCPExecutor):
         :param str loglevel: redis log verbosity level
         :param str host: server's host
         :param int port: server's port
-        :param int timeout: executor's timeout for start and stop actions
+        :param int startup_timeout: executor's timeout for start and stop actions
         :param str log_prefix: prefix for log filename
         :param str save: redis save configuration setting
         :param str daemonize:
@@ -197,7 +198,7 @@ class RedisExecutor(TCPExecutor):
             else:
                 command.extend([f"--save {save}"])
 
-        super().__init__(command, host, port, timeout=timeout)
+        super().__init__(command, host, port, timeout=startup_timeout)
 
     @classmethod
     def _redis_bool(cls, value):

--- a/src/pytest_redis/executor.py
+++ b/src/pytest_redis/executor.py
@@ -19,7 +19,7 @@
 import os
 import platform
 import re
-from collections import namedtuple
+import socket
 from itertools import islice
 from pathlib import Path
 from tempfile import gettempdir
@@ -57,7 +57,37 @@ class UnixSocketTooLong(Exception):
     """Exception raised when unixsocket path is too long."""
 
 
-NoopRedis = namedtuple("NoopRedis", "host, port, unixsocket")
+class NoopRedis(TCPExecutor):
+    """Reddis class respsenting an instance started by a third party."""
+    def __init__(self, host, port, unixsocket, timeout=15):
+        """
+        Init method of NoopRedis.
+
+        :param str host: server's host
+        :param int port: server's port
+        :param int timeout: executor's timeout for start and stop actions
+        """
+        self.host = host
+        self.port = port
+        self.unixsocket = unixsocket
+        self.timeout = timeout
+        super().__init__([], host, port, timeout=timeout)
+
+    def start(self):
+        """Start is a NOOP."""
+        self._set_timeout()
+        self.wait_for(self.redis_available)
+        return self
+
+    def redis_available(self):
+        """Return True if connecting to Redis is possible"""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.settimeout(0.1)
+                s.connect((self.host, self.port))
+            except (TimeoutError, ConnectionRefusedError):
+                return False
+        return True
 
 
 class RedisExecutor(TCPExecutor):

--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -126,7 +126,7 @@ def redis_proc(
             save=save or config["save"],
             host=host or config["host"],
             port=get_port(port) or get_port(config["port"]),
-            timeout=60,
+            startup_timeout=60,
             datadir=redis_datadir,
         )
         redis_executor.start()
@@ -137,13 +137,13 @@ def redis_proc(
     return redis_proc_fixture
 
 
-def redis_noproc(host=None, port=None, timeout=15):
+def redis_noproc(host=None, port=None, startup_timeout=15):
     """
     Nooproc fixture factory for pytest-redis.
 
     :param str host: hostname
     :param str|int port: exact port (e.g. '8000', 8000)
-    :param int timeout: Blocking wait until we give up connecting to Redis.
+    :param int startup_timeout: Blocking wait until we give up connecting to Redis.
     :rtype: func
     :returns: function which makes a redis process
     """
@@ -161,7 +161,10 @@ def redis_noproc(host=None, port=None, timeout=15):
         """
         config = get_config(request)
         redis_noopexecutor = NoopRedis(
-            host=host or config["host"], port=port or config["port"] or 6379, unixsocket=None, timeout=timeout
+            host=host or config["host"],
+            port=port or config["port"] or 6379,
+            unixsocket=None,
+            startup_timeout=startup_timeout,
         )
 
         redis_noopexecutor.start()

--- a/src/pytest_redis/factories.py
+++ b/src/pytest_redis/factories.py
@@ -137,12 +137,13 @@ def redis_proc(
     return redis_proc_fixture
 
 
-def redis_noproc(host=None, port=None):
+def redis_noproc(host=None, port=None, timeout=15):
     """
     Nooproc fixture factory for pytest-redis.
 
     :param str host: hostname
     :param str|int port: exact port (e.g. '8000', 8000)
+    :param int timeout: Blocking wait until we give up connecting to Redis.
     :rtype: func
     :returns: function which makes a redis process
     """
@@ -160,9 +161,10 @@ def redis_noproc(host=None, port=None):
         """
         config = get_config(request)
         redis_noopexecutor = NoopRedis(
-            host=host or config["host"], port=port or config["port"] or 6379, unixsocket=None
+            host=host or config["host"], port=port or config["port"] or 6379, unixsocket=None, timeout=timeout
         )
 
+        redis_noopexecutor.start()
         return redis_noopexecutor
 
     return redis_nooproc_fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ warnings.filterwarnings(
 
 # pylint:disable=invalid-name
 redis_proc2 = factories.redis_proc(port=6381)
-redis_nooproc2 = factories.redis_noproc(port=6381, timeout=1)
+redis_nooproc2 = factories.redis_noproc(port=6381, startup_timeout=1)
 redisdb2 = factories.redisdb("redis_proc2")
 redisdb2_noop = factories.redisdb("redis_nooproc2")
 # pylint:enable=invalid-name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ warnings.filterwarnings(
 
 # pylint:disable=invalid-name
 redis_proc2 = factories.redis_proc(port=6381)
-redis_nooproc2 = factories.redis_noproc(port=6381)
+redis_nooproc2 = factories.redis_noproc(port=6381, timeout=1)
 redisdb2 = factories.redisdb("redis_proc2")
 redisdb2_noop = factories.redisdb("redis_nooproc2")
 # pylint:enable=invalid-name

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -50,7 +50,7 @@ def test_redis_exec_configuration(
         loglevel=config["loglevel"],
         port=get_port(None),
         host=config["host"],
-        timeout=30,
+        startup_timeout=30,
         datadir=tmpdir,
         **parameter,
     )
@@ -81,7 +81,7 @@ def test_redis_exec(request: FixtureRequest, tmp_path_factory: TempPathFactory, 
         loglevel=config["loglevel"],
         port=get_port(None),
         host=config["host"],
-        timeout=30,
+        startup_timeout=30,
         datadir=tmpdir,
         **parameter,
     )
@@ -131,7 +131,7 @@ def test_old_redis_version(request: FixtureRequest, tmp_path_factory: TempPathFa
                 loglevel=config["loglevel"],
                 port=get_port(None),
                 host=config["host"],
-                timeout=30,
+                startup_timeout=30,
                 datadir=tmpdir,
             ).start()
 
@@ -148,7 +148,7 @@ def test_not_existing_redis(request: FixtureRequest, tmp_path_factory: TempPathF
             loglevel=config["loglevel"],
             port=get_port(None),
             host=config["host"],
-            timeout=30,
+            startup_timeout=30,
             datadir=tmpdir,
         ).start()
 
@@ -165,7 +165,7 @@ def test_too_long_unixsocket(request: FixtureRequest, tmp_path_factory: TempPath
             loglevel=config["loglevel"],
             port=get_port(None),
             host=config["host"],
-            timeout=30,
+            startup_timeout=30,
             datadir=tmpdir,
         ).start()
 
@@ -196,7 +196,7 @@ def test_noopredis_handles_timeout_when_waiting():
         foo = patched_socket.socket.return_value
         socket_mock = foo.__enter__.return_value
         socket_mock.connect.side_effect = TimeoutError()
-        noop_redis = NoopRedis('localhost', 12345, None, timeout=1)
+        noop_redis = NoopRedis('localhost', 12345, None, startup_timeout=1)
         with pytest.raises(TimeoutExpired):
             noop_redis.start()
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -192,11 +192,11 @@ def test_extract_version_notfound():
 
 
 def test_noopredis_handles_timeout_when_waiting():
-    with mock.patch('pytest_redis.executor.socket', spec=socket) as patched_socket:
+    with mock.patch("pytest_redis.executor.socket", spec=socket) as patched_socket:
         foo = patched_socket.socket.return_value
         socket_mock = foo.__enter__.return_value
         socket_mock.connect.side_effect = TimeoutError()
-        noop_redis = NoopRedis('localhost', 12345, None, startup_timeout=1)
+        noop_redis = NoopRedis("localhost", 12345, None, startup_timeout=1)
         with pytest.raises(TimeoutExpired):
             noop_redis.start()
 


### PR DESCRIPTION
The `redis_nooproc` was a NOOP named tuple. The fixture is usually used
when users control their own redis instance. It would be easy to assume,
that the fixture would wait (block) for the server to be ready to
connect to. This was not the case.

Change the data structure to a class inheriting from `TCPExecutor`. The
start up routine now wait's for the fixture to create a successful
socket connection before the timout is met, otherwise fail.

Note: This only uses `AF_INET` sockets (no IPv6 support).

Fixes #388