### PR TITLE
Remove strict redis selection since there's no longer any difference …

### DIFF
--- a/newsfragments/447.misc.rst
+++ b/newsfragments/447.misc.rst
@@ -1,0 +1,2 @@
+Removed the bit hidden ability to select over Redis/StrictRedis client for client fixture.
+For a long time both were same client already.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pytest >= 6.2",
     "port-for >= 0.6.0",
     "mirakuru",
-    "redis",
+    "redis >= 3",
 ]
 requires-python = ">= 3.8"
 

--- a/pytest_redis/factories.py
+++ b/pytest_redis/factories.py
@@ -223,15 +223,14 @@ def redis_noproc(
 
 
 def redisdb(
-    process_fixture_name: str, dbnum: int = 0, strict: bool = True, decode: Optional[bool] = None
+    process_fixture_name: str, dbnum: int = 0, decode: Optional[bool] = None
 ) -> Callable[[FixtureRequest], Generator[redis.Redis, None, None]]:
     """
     Create connection fixture factory for pytest-redis.
 
     :param process_fixture_name: name of the process fixture
     :param dbnum: number of database to use
-    :param strict: if true, uses StrictRedis client class
-    :param decode_responses: Client: to decode response or not.
+    :param decode: Client: to decode response or not.
         See redis.StrictRedis decode_reponse client parameter.
     :returns: function which makes a connection to redis
     """
@@ -260,12 +259,11 @@ def redisdb(
         redis_username = proc_fixture.username
         redis_password = proc_fixture.password
         redis_db = dbnum
-        redis_class = redis.StrictRedis if strict else redis.Redis
         decode_responses: Union[Literal[True], Literal[False]] = (
             decode if decode is not None else config["decode"]
         )
 
-        redis_client = redis_class(
+        redis_client = redis.Redis(
             redis_host,
             redis_port,
             redis_db,


### PR DESCRIPTION
…- closes #447

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number