### PR TITLE
Include py.typed in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include *.rst *.py
+include *.rst *.py pytest_redis/py.typed
 recursive-include src/pytest_redis *.py
 prune docs/build

--- a/newsfragments/471.bugfix.rst
+++ b/newsfragments/471.bugfix.rst
@@ -1,0 +1,1 @@
+Include py.typed in MANIFEST.in


### PR DESCRIPTION
Fixes #470. This problem seems similar to one described in a [similar httpx issue thread](https://github.com/encode/httpx/issues/193#issuecomment-533188015). Their ultimate solution led to a change to `setup.py` file, but since this project does not have a `setup.py` we can modify the `MANIFEST.in` instead to achieve the same results. 

I ran the following commands, both before my change and after, to list out the results of the generated distribution:
```sh
python -m build . 
tar -xvf dist/pytest-redis-3.0.1.tar.gz 
ls -l pytest-redis-3.0.1/pytest_redis 
```

Final output before:
```
-rw-r--r--  1 max  staff   861 Apr 19 01:43 __init__.py
-rw-r--r--  1 max  staff  1527 Apr 19 01:43 config.py
-rw-r--r--  1 max  staff   343 Apr 19 01:43 exception.py
drwxr-xr-x  5 max  staff   160 Apr 19 01:46 executor
drwxr-xr-x  6 max  staff   192 Apr 19 01:46 factories
-rw-r--r--  1 max  staff  5021 Apr 19 01:43 plugin.py
```

Final output after:
```
-rw-r--r--  1 max  staff   861 Apr 19 01:43 __init__.py
-rw-r--r--  1 max  staff  1527 Apr 19 01:43 config.py
-rw-r--r--  1 max  staff   343 Apr 19 01:43 exception.py
drwxr-xr-x  5 max  staff   160 Apr 19 01:46 executor
drwxr-xr-x  6 max  staff   192 Apr 19 01:46 factories
-rw-r--r--  1 max  staff  5021 Apr 19 01:43 plugin.py
-rw-r--r--  1 max  staff     0 Apr 19 01:43 py.typed
```
The `py.typed` file is present in the "after" output as expected. 

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number