### PR TITLE
Drop old python package caching in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,30 +22,8 @@ jobs:
         key: redis-${{ hashFiles('.download-redis.sh') }}
     - name: Download and build Redis
       run: ./.download-redis.sh
-  install_py:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: [3.8, 3.9, "3.10", pypy-3.9]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: pip cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('requirements-*.txt') }}
-          restore-keys: |
-            pip-${{ matrix.python-version }}-
   tests_7:
-    needs: [download_redis, install_py]
+    needs: [download_redis]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/newsfragments/674.misc.rst
+++ b/newsfragments/674.misc.rst
@@ -1,0 +1,1 @@
+Drop old install_py test step, that's supposed to install packages for caching purposes.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number