### PR TITLE
Fix broken factories module - closes #679

### DIFF
--- a/newsfragments/679.bugfix.rst
+++ b/newsfragments/679.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed redis factories module, where imports from submodule
+on the main `factories` level were removed by linter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ include = '.*\.pyi?$'
 [tool.ruff]
 # Decrease the maximum line length to 79 characters.
 line-length = 100
-select = [
+lint.select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort

--- a/pytest_redis/factories/__init__.py
+++ b/pytest_redis/factories/__init__.py
@@ -1,1 +1,7 @@
 """Redis fixture factories."""
+
+from pytest_redis.factories.client import redisdb
+from pytest_redis.factories.noproc import redis_noproc
+from pytest_redis.factories.proc import redis_proc
+
+__all__ = ("redis_proc", "redis_noproc", "redisdb")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,7 @@
 
 import warnings
 
-import pytest_redis.factories.client
-import pytest_redis.factories.noproc
-import pytest_redis.factories.proc
+import pytest_redis.factories
 from pytest_redis.plugin import *  # noqa: F403
 
 warnings.filterwarnings(
@@ -12,13 +10,13 @@ warnings.filterwarnings(
 )
 
 # pylint:disable=invalid-name
-redis_proc2 = pytest_redis.factories.proc.redis_proc(port=6381)
-redis_nooproc2 = pytest_redis.factories.noproc.redis_noproc(port=6381, startup_timeout=1)
-redis_proc3 = pytest_redis.factories.proc.redis_proc(port=6385, password="secretpassword")
-redis_nooproc3 = pytest_redis.factories.noproc.redis_noproc(port=6385, password="secretpassword")
+redis_proc2 = pytest_redis.factories.redis_proc(port=6381)
+redis_nooproc2 = pytest_redis.factories.redis_noproc(port=6381, startup_timeout=1)
+redis_proc3 = pytest_redis.factories.redis_proc(port=6385, password="secretpassword")
+redis_nooproc3 = pytest_redis.factories.redis_noproc(port=6385, password="secretpassword")
 
-redisdb2 = pytest_redis.factories.client.redisdb("redis_proc2")
-redisdb2_noop = pytest_redis.factories.client.redisdb("redis_nooproc2")
-redisdb3 = pytest_redis.factories.client.redisdb("redis_proc3")
-redisdb3_noop = pytest_redis.factories.client.redisdb("redis_nooproc3")
+redisdb2 = pytest_redis.factories.redisdb("redis_proc2")
+redisdb2_noop = pytest_redis.factories.redisdb("redis_nooproc2")
+redisdb3 = pytest_redis.factories.redisdb("redis_proc3")
+redisdb3_noop = pytest_redis.factories.redisdb("redis_nooproc3")
 # pylint:enable=invalid-name


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number