### PR TITLE
Update actions/pytest dependencies

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -14,37 +14,27 @@ runs:
   using: "composite"
   steps:
   - name: Set up Python ${{ inputs.python-version }}
-    uses: actions/setup-python@v3
+    uses: actions/setup-python@v6
     with:
       python-version: ${{ inputs.python-version }}
   - name: Cache Redis builds
-    uses: actions/cache@v3
+    uses: actions/cache@v5
     with:
       path: ~/redis
       key: redis-${{ hashFiles('.download-redis.sh') }}
-  - name: Get pip cache dir
-    id: pip-cache
-    shell: bash
-    run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-  - name: pip cache
-    uses: actions/cache@v3
-    with:
-      path: ${{ steps.pip-cache.outputs.dir }}
-      key: pip-${{ inputs.python-version }}-${{ hashFiles('requirements-*.txt') }}
-      restore-keys: |
-        pip-${{ matrix.python-version }}-
   - name: Run test on Redis ${{ inputs.redis }}
-    uses: fizyk/actions-reuse/.github/actions/pipenv@v1.7.1
+    uses: fizyk/actions-reuse/.github/actions/pipenv@v4.4.0
     with:
-      python-version: ${{ matrix.python-version }}
+      python-version: ${{ inputs.python-version }}
       command: pytest -n 0 --cov-report=xml --redis-exec=$HOME/redis/redis-${{ inputs.redis }}/src/redis-server
+      allow-prereleases: true
   - name: Run xdist test on Redis ${{ inputs.redis }}
-    uses: fizyk/actions-reuse/.github/actions/pipenv@v1.7.1
+    uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.0
     with:
-      python-version: ${{ matrix.python-version }}
+      python-version: ${{ inputs.python-version }}
       command: pytest -n 1 --cov-report=xml:coverage-xdist.xml --redis-exec=$HOME/redis/redis-${{ inputs.redis }}/src/redis-server
   - name: Upload coverage to Codecov
-    uses: codecov/codecov-action@v3.0.0
+    uses: codecov/codecov-action@v5
     with:
       flags: linux,redis-${{ inputs.redis }}
       env_vars: OS, PYTHON

--- a/newsfragments/+e4616243.misc.rst
+++ b/newsfragments/+e4616243.misc.rst
@@ -1,0 +1,1 @@
+Update really old composite actions in internal actions/pytest


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow tooling and GitHub Actions to newer action versions.
  * Removed legacy pip cache steps and simplified caching.
  * Adjusted Python dependency runner usage and inputs for test runs.
  * Enabled prerelease allowances for Redis tests.
  * Updated coverage upload action.
  * Added a changelog/news fragment noting the CI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->