### PR TITLE
Support Python 3.14, drop support for python 3.9 - closes #900

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", pypy-3.10]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", pypy-3.10]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", pypy-3.10]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/newsfragments/900.break.rst
+++ b/newsfragments/900.break.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.9

--- a/newsfragments/900.feature.rst
+++ b/newsfragments/900.feature.rst
@@ -1,0 +1,1 @@
+Mark support for Python 3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
@@ -33,7 +33,7 @@ dependencies = [
     "mirakuru",
     "redis >= 3",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [project.urls]
 "Source" = "https://github.com/dbfixtures/pytest-redis"
@@ -62,7 +62,7 @@ testpaths = "tests"
 
 [tool.black]
 line-length = 100
-target-version = ['py39']
+target-version = ['py310']
 include = '.*\.pyi?$'
 
 [tool.ruff]

--- a/pytest_redis/config.py
+++ b/pytest_redis/config.py
@@ -1,6 +1,6 @@
 """Config loading helpers."""
 
-from typing import Any, List, Optional, TypedDict
+from typing import Any, TypedDict
 
 from _pytest.fixtures import FixtureRequest
 
@@ -9,7 +9,7 @@ class RedisConfigType(TypedDict):
     """Pytest redis config definition type."""
 
     host: str
-    port: Optional[int]
+    port: int | None
     username: str
     password: str
     exec: str
@@ -22,7 +22,7 @@ class RedisConfigType(TypedDict):
     syslog: bool
     decode: bool
     datadir: str
-    modules: List[str]
+    modules: list[str]
 
 
 def get_config(request: FixtureRequest) -> RedisConfigType:

--- a/pytest_redis/executor/noop.py
+++ b/pytest_redis/executor/noop.py
@@ -1,7 +1,6 @@
 """Reddis class respsenting an instance started by a third party."""
 
 import socket
-from typing import Optional
 
 from mirakuru import TCPExecutor
 
@@ -13,9 +12,9 @@ class NoopRedis(TCPExecutor):
         self,
         host: str,
         port: int,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-        unixsocket: Optional[str] = None,
+        username: str | None = None,
+        password: str | None = None,
+        unixsocket: str | None = None,
         startup_timeout: int = 15,
     ) -> None:
         """Init method of NoopRedis.

--- a/pytest_redis/executor/process.py
+++ b/pytest_redis/executor/process.py
@@ -6,7 +6,7 @@ import re
 from itertools import islice
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 
 from mirakuru import TCPExecutor
 from packaging.version import Version, parse
@@ -48,8 +48,8 @@ class RedisExecutor(TCPExecutor):
         loglevel: str,
         host: str,
         port: int,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
+        username: str | None = None,
+        password: str | None = None,
         startup_timeout: int = 60,
         save: str = "",
         daemonize: str = "no",
@@ -57,8 +57,8 @@ class RedisExecutor(TCPExecutor):
         rdbchecksum: bool = False,
         syslog_enabled: bool = False,
         appendonly: str = "no",
-        datadir: Optional[Path] = None,
-        modules: Optional[List[str]] = None,
+        datadir: Path | None = None,
+        modules: list[str] | None = None,
     ) -> None:  # pylint:disable=too-many-locals
         """Init method of a RedisExecutor.
 

--- a/pytest_redis/factories/client.py
+++ b/pytest_redis/factories/client.py
@@ -1,6 +1,6 @@
 """Redis client fixture factory."""
 
-from typing import Callable, Generator, Literal, Optional, Union
+from typing import Callable, Generator, Literal
 
 import pytest
 import redis
@@ -11,7 +11,7 @@ from pytest_redis.executor import NoopRedis, RedisExecutor
 
 
 def redisdb(
-    process_fixture_name: str, dbnum: int = 0, decode: Optional[bool] = None
+    process_fixture_name: str, dbnum: int = 0, decode: bool | None = None
 ) -> Callable[[FixtureRequest], Generator[redis.Redis, None, None]]:
     """Create connection fixture factory for pytest-redis.
 
@@ -35,9 +35,7 @@ def redisdb(
         :rtype: redis.client.Redis
         :returns: Redis client
         """
-        proc_fixture: Union[NoopRedis, RedisExecutor] = request.getfixturevalue(
-            process_fixture_name
-        )
+        proc_fixture: NoopRedis | RedisExecutor = request.getfixturevalue(process_fixture_name)
         config = get_config(request)
 
         redis_host = proc_fixture.host
@@ -45,7 +43,7 @@ def redisdb(
         redis_username = proc_fixture.username
         redis_password = proc_fixture.password
         redis_db = dbnum
-        decode_responses: Union[Literal[True], Literal[False]] = (
+        decode_responses: Literal[True] | Literal[False] = (
             decode if decode is not None else config["decode"]
         )
 

--- a/pytest_redis/factories/noproc.py
+++ b/pytest_redis/factories/noproc.py
@@ -1,6 +1,6 @@
 """Redis noop fixture factory."""
 
-from typing import Callable, Generator, Optional
+from typing import Callable, Generator
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -10,10 +10,10 @@ from pytest_redis.executor import NoopRedis
 
 
 def redis_noproc(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    username: str | None = None,
+    password: str | None = None,
     startup_timeout: int = 15,
 ) -> Callable[[FixtureRequest], Generator[NoopRedis, None, None]]:
     """Nooproc fixture factory for pytest-redis.

--- a/pytest_redis/factories/proc.py
+++ b/pytest_redis/factories/proc.py
@@ -1,44 +1,32 @@
 """Redis process fixture factory."""
 
 from pathlib import Path
-from typing import Callable, Generator, List, Optional, Set, Tuple, Union
+from typing import Callable, Generator
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempPathFactory
-from port_for import get_port
+from port_for import PortType, get_port
 
 from pytest_redis.config import get_config
 from pytest_redis.executor import RedisExecutor
 
 
 def redis_proc(
-    executable: Optional[str] = None,
-    timeout: Optional[int] = None,
-    host: Optional[str] = None,
-    port: Union[
-        None,
-        str,
-        int,
-        Tuple[int, int],
-        Set[int],
-        List[str],
-        List[int],
-        List[Tuple[int, int]],
-        List[Set[int]],
-        List[Union[Set[int], Tuple[int, int]]],
-        List[Union[str, int, Tuple[int, int], Set[int]]],
-    ] = -1,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-    db_count: Optional[int] = None,
-    save: Optional[str] = None,
-    compression: Optional[bool] = None,
-    checksum: Optional[bool] = None,
-    syslog: Optional[bool] = None,
-    loglevel: Optional[str] = None,
-    datadir: Optional[str] = None,
-    modules: Optional[List[str]] = None,
+    executable: str | None = None,
+    timeout: int | None = None,
+    host: str | None = None,
+    port: PortType = -1,
+    username: str | None = None,
+    password: str | None = None,
+    db_count: int | None = None,
+    save: str | None = None,
+    compression: bool | None = None,
+    checksum: bool | None = None,
+    syslog: bool | None = None,
+    loglevel: str | None = None,
+    datadir: str | None = None,
+    modules: list[str] | None = None,
 ) -> Callable[[FixtureRequest, TempPathFactory], Generator[RedisExecutor, None, None]]:
     """Fixture factory for pytest-redis.
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,7 +2,7 @@
 
 import socket
 from io import StringIO
-from typing import Any, Dict, Literal
+from typing import Any, Literal
 
 import pytest
 import redis
@@ -35,7 +35,7 @@ from pytest_redis.executor.process import extract_version
 def test_redis_exec_configuration(
     request: FixtureRequest,
     tmp_path_factory: TempPathFactory,
-    parameter: Dict[str, Any],
+    parameter: dict[str, Any],
     config_option: str,
     value: str,
 ) -> None:


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Dropped support for Python 3.9; minimum required version is now Python 3.10.

* **New Features**
  * Added support for Python 3.14.

* **Chores**
  * CI updated to test Python 3.10–3.14 and PyPy 3.11.
  * Modernised type annotations across public APIs to PEP 604 union syntax (may affect static type checkers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->